### PR TITLE
Revert "migration to material-ui-pickers 2.x"

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,9 +1,7 @@
 {
-  "extends": "airbnb",
-  "rules": {
-    "react/jsx-filename-extension": 0,
-    "react/forbid-prop-types": 0
-  },
-  "env": { "es6": true },
-  "parser": "babel-eslint"
+    "extends": "airbnb",
+    "rules": {
+        "react/jsx-filename-extension": 0,
+        "react/forbid-prop-types": 0
+    }
 }

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,0 @@
-*.js text eol=lf

--- a/lib/index.js
+++ b/lib/index.js
@@ -21,9 +21,13 @@ var _raCore = require('ra-core');
 
 var _materialUiPickers = require('material-ui-pickers');
 
-var _dateFns = require('@date-io/date-fns');
+var _dateFnsUtils = require('material-ui-pickers/utils/date-fns-utils');
 
-var _dateFns2 = _interopRequireDefault(_dateFns);
+var _dateFnsUtils2 = _interopRequireDefault(_dateFnsUtils);
+
+var _MuiPickersUtilsProvider = require('material-ui-pickers/utils/MuiPickersUtilsProvider');
+
+var _MuiPickersUtilsProvider2 = _interopRequireDefault(_MuiPickersUtilsProvider);
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
@@ -38,23 +42,18 @@ var makePicker = function makePicker(PickerComponent) {
     _inherits(_makePicker, _Component);
 
     function _makePicker() {
-      var _ref;
-
-      var _temp, _this, _ret;
-
       _classCallCheck(this, _makePicker);
 
-      for (var _len = arguments.length, args = Array(_len), _key = 0; _key < _len; _key++) {
-        args[_key] = arguments[_key];
-      }
-
-      return _ret = (_temp = (_this = _possibleConstructorReturn(this, (_ref = _makePicker.__proto__ || Object.getPrototypeOf(_makePicker)).call.apply(_ref, [this].concat(args))), _this), _this.onChange = function (date) {
-        _this.props.input.onChange(date);
-        _this.props.input.onBlur();
-      }, _temp), _possibleConstructorReturn(_this, _ret);
+      return _possibleConstructorReturn(this, (_makePicker.__proto__ || Object.getPrototypeOf(_makePicker)).apply(this, arguments));
     }
 
     _createClass(_makePicker, [{
+      key: 'onChange',
+      value: function onChange(date) {
+        this.props.input.onChange(date);
+        this.props.input.onBlur();
+      }
+    }, {
       key: 'render',
       value: function render() {
         var _this2 = this;
@@ -77,7 +76,7 @@ var makePicker = function makePicker(PickerComponent) {
           'div',
           { className: 'picker' },
           _react2.default.createElement(
-            _materialUiPickers.MuiPickersUtilsProvider,
+            _MuiPickersUtilsProvider2.default,
             providerOptions,
             _react2.default.createElement(PickerComponent, _extends({}, options, {
               label: _react2.default.createElement(_raCore.FieldTitle, {
@@ -94,7 +93,9 @@ var makePicker = function makePicker(PickerComponent) {
               },
               className: className,
               value: input.value ? input.value : null,
-              onChange: this.onChange
+              onChange: function onChange(date) {
+                return _this2.onChange(date);
+              }
             }))
           )
         );
@@ -131,7 +132,7 @@ var makePicker = function makePicker(PickerComponent) {
     labelTime: '',
     className: '',
     providerOptions: {
-      utils: _dateFns2.default,
+      utils: _dateFnsUtils2.default,
       locale: undefined
     }
   };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,59 +1,9 @@
 {
   "name": "react-admin-date-inputs",
-  "version": "1.1.0",
+  "version": "1.0.21",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "@babel/runtime": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.2.0.tgz",
-      "integrity": "sha512-oouEibCbHMVdZSDlJBO6bZmID/zA/G/Qx3H1d3rSNPTD+L8UNKvCat7aKWSJ74zYbm5zWGh0GQN0hKj8zYFTCg==",
-      "requires": {
-        "regenerator-runtime": "0.12.1"
-      },
-      "dependencies": {
-        "regenerator-runtime": {
-          "version": "0.12.1",
-          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz",
-          "integrity": "sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg=="
-        }
-      }
-    },
-    "@date-io/core": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@date-io/core/-/core-1.0.1.tgz",
-      "integrity": "sha512-vUdpOjCyjjDXjooyy+1MGCbw2BI00M/avAk+S8hQVs8CrLW78w7HdPFfVVpywC5f1ygueGc6IkSBVj0yawYGEg=="
-    },
-    "@date-io/date-fns": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@date-io/date-fns/-/date-fns-1.0.1.tgz",
-      "integrity": "sha512-egGn37+ReN1OhxfwiwngOiddalzauENg7Lf53EbcxlYYw8SRgxmvS5zxdG07AlDrPLCQg5tGqpqLyj3o3nsj0A==",
-      "requires": {
-        "@date-io/core": "1.0.1"
-      }
-    },
-    "@types/prop-types": {
-      "version": "15.5.8",
-      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.5.8.tgz",
-      "integrity": "sha512-3AQoUxQcQtLHsK25wtTWIoIpgYjH3vSDroZOUr7PpCHw/jLY1RB9z9E8dBT/OSmwStVgkRNvdh+ZHNiomRieaw=="
-    },
-    "@types/react": {
-      "version": "16.7.20",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.7.20.tgz",
-      "integrity": "sha512-Qd5RWkwl6SL7R2XzLk/cicjVQm1Mhc6HqXY5Ei4pWd1Vi8Fkbd5O0sA398x8fRSTPAuHdDYD9nrWmJMYTJI0vQ==",
-      "requires": {
-        "@types/prop-types": "15.5.8",
-        "csstype": "2.6.1"
-      }
-    },
-    "@types/react-text-mask": {
-      "version": "5.4.3",
-      "resolved": "https://registry.npmjs.org/@types/react-text-mask/-/react-text-mask-5.4.3.tgz",
-      "integrity": "sha512-+/uibOQ07X4om3+dPMpxUGdw76u4d4HQ9qCPs2syFtwmpTlnOyAJaIW89t+QX/DXI+Ar+SKch6A4stoLg5RdLw==",
-      "requires": {
-        "@types/react": "16.7.20"
-      }
-    },
     "acorn": {
       "version": "5.6.2",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.6.2.tgz",
@@ -1516,11 +1466,6 @@
         "which": "1.3.1"
       }
     },
-    "csstype": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.1.tgz",
-      "integrity": "sha512-wv7IRqCGsL7WGKB8gPvrl+++HlFM9kxAM6jL1EXNPNTshEJYilMkbfS2SnuHha77uosp/YVK0wAp2jmlBzn1tg=="
-    },
     "damerau-levenshtein": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.4.tgz",
@@ -1528,9 +1473,9 @@
       "dev": true
     },
     "date-fns": {
-      "version": "2.0.0-alpha.25",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.0.0-alpha.25.tgz",
-      "integrity": "sha512-iQzJkHF0L4wah9Ae9PkvwemwFz6qmRLuNZcghmvf2t+ptLs1qXzONLiGtjmPQzL6+JpC01JjlTopY2AEy4NFAg=="
+      "version": "2.0.0-alpha.16",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.0.0-alpha.16.tgz",
+      "integrity": "sha1-0kmmybeZJSZS+54/JUYOr53oasc="
     },
     "debug": {
       "version": "2.6.9",
@@ -1591,12 +1536,9 @@
       }
     },
     "dom-helpers": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-3.4.0.tgz",
-      "integrity": "sha512-LnuPJ+dwqKDIyotW1VzmOZ5TONUN7CwkCR5hrgawTUbkBGYdeoNLZo6nNfGkCrjtE1nXXaj7iMMpDa8/d9WoIA==",
-      "requires": {
-        "@babel/runtime": "7.2.0"
-      }
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-3.3.1.tgz",
+      "integrity": "sha512-2Sm+JaYn74OiTM2wHvxJOo3roiq/h25Yi69Fqk269cNUwIXsCvATB6CRSFC9Am/20G2b28hGv/+7NiWydIrPvg=="
     },
     "emoji-regex": {
       "version": "6.5.1",
@@ -3131,11 +3073,6 @@
         "array-includes": "3.0.3"
       }
     },
-    "keycode": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/keycode/-/keycode-2.2.0.tgz",
-      "integrity": "sha1-PQr1bce4uOXLqNCpfxByBO7CKwQ="
-    },
     "kind-of": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
@@ -3222,17 +3159,80 @@
       }
     },
     "material-ui-pickers": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/material-ui-pickers/-/material-ui-pickers-2.1.1.tgz",
-      "integrity": "sha512-p4qxZv+kkhFAGdw172lFLmbA127kUS8XkqlTPWu2km7f+FRHzk1b4GwP63FEXB+dzhj+xa5VJ7WltaLxUMROTg==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/material-ui-pickers/-/material-ui-pickers-1.0.0-rc.17.tgz",
+      "integrity": "sha512-mzNbMmqTkPhZqfb2nVQ1jBIOb0QUDTMVs6RnqTccCnqPJ8iea5d+P9KTnjyObkeE+Kt0+Fn7OX1+v/w3h0tbHg==",
       "requires": {
-        "@types/react-text-mask": "5.4.3",
+        "@babel/runtime": "7.1.5",
         "classnames": "2.2.6",
-        "keycode": "2.2.0",
-        "react-event-listener": "0.6.5",
+        "react-event-listener": "0.6.4",
         "react-text-mask": "5.4.1",
-        "react-transition-group": "2.5.3",
-        "tslib": "1.9.3"
+        "react-transition-group": "2.5.0"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.1.5",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.1.5.tgz",
+          "integrity": "sha512-xKnPpXG/pvK1B90JkwwxSGii90rQGKtzcMt2gI5G6+M0REXaq6rOHsGC2ay6/d0Uje7zzvSzjEzfR3ENhFlrfA==",
+          "requires": {
+            "regenerator-runtime": "0.12.1"
+          }
+        },
+        "loose-envify": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+          "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+          "requires": {
+            "js-tokens": "3.0.2"
+          }
+        },
+        "react-event-listener": {
+          "version": "0.6.4",
+          "resolved": "https://registry.npmjs.org/react-event-listener/-/react-event-listener-0.6.4.tgz",
+          "integrity": "sha512-t7VSjIuUFmN+GeyKb+wm025YLeojVB85kJL6sSs0wEBJddfmKBEQz+CNBZ2zBLKVWkPy/fZXM6U5yvojjYBVYQ==",
+          "requires": {
+            "@babel/runtime": "7.0.0",
+            "prop-types": "15.6.1",
+            "warning": "4.0.2"
+          },
+          "dependencies": {
+            "@babel/runtime": {
+              "version": "7.0.0",
+              "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.0.0.tgz",
+              "integrity": "sha512-7hGhzlcmg01CvH1EHdSPVXYX1aJ8KCEyz6I9xYIi/asDtzBPMyMhVibhM/K6g/5qnKBwjZtp10bNZIEFTRW1MA==",
+              "requires": {
+                "regenerator-runtime": "0.12.1"
+              }
+            }
+          }
+        },
+        "react-transition-group": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-2.5.0.tgz",
+          "integrity": "sha512-qYB3JBF+9Y4sE4/Mg/9O6WFpdoYjeeYqx0AFb64PTazVy8RPMiE3A47CG9QmM4WJ/mzDiZYslV+Uly6O1Erlgw==",
+          "requires": {
+            "dom-helpers": "3.3.1",
+            "loose-envify": "1.4.0",
+            "prop-types": "15.6.2",
+            "react-lifecycles-compat": "3.0.4"
+          },
+          "dependencies": {
+            "prop-types": {
+              "version": "15.6.2",
+              "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.2.tgz",
+              "integrity": "sha512-3pboPvLiWD7dkI3qf3KbUe6hKFKa52w+AE0VCqECtf+QHAKgOL37tTaNCnuX1nAAQ4ZhyP+kYVKf8rLmJ/feDQ==",
+              "requires": {
+                "loose-envify": "1.4.0",
+                "object-assign": "4.1.1"
+              }
+            }
+          }
+        },
+        "regenerator-runtime": {
+          "version": "0.12.1",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz",
+          "integrity": "sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg=="
+        }
       }
     },
     "math-random": {
@@ -3645,16 +3645,6 @@
         }
       }
     },
-    "react-event-listener": {
-      "version": "0.6.5",
-      "resolved": "https://registry.npmjs.org/react-event-listener/-/react-event-listener-0.6.5.tgz",
-      "integrity": "sha512-//lCxOM3DQ0+xmTa/u9mI9mm55zCPdIKp89d8MGjlNsOOnXQ5sFDD1eed+sMBzQXKiRBLBMtSg/2T9RJFtfovw==",
-      "requires": {
-        "@babel/runtime": "7.2.0",
-        "prop-types": "15.6.1",
-        "warning": "4.0.2"
-      }
-    },
     "react-lifecycles-compat": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
@@ -3666,36 +3656,6 @@
       "integrity": "sha512-mGx1n0x0skktwsKcpgAGnrgExFlXDflbWEHh8PC1UaQP8+EdHkW7JYczTghsBo2rnVwU9/4A9x/2bVt3HY46/w==",
       "requires": {
         "prop-types": "15.6.1"
-      }
-    },
-    "react-transition-group": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-2.5.3.tgz",
-      "integrity": "sha512-2DGFck6h99kLNr8pOFk+z4Soq3iISydwOFeeEVPjTN6+Y01CmvbWmnN02VuTWyFdnRtIDPe+wy2q6Ui8snBPZg==",
-      "requires": {
-        "dom-helpers": "3.4.0",
-        "loose-envify": "1.4.0",
-        "prop-types": "15.6.2",
-        "react-lifecycles-compat": "3.0.4"
-      },
-      "dependencies": {
-        "loose-envify": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
-          "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-          "requires": {
-            "js-tokens": "3.0.2"
-          }
-        },
-        "prop-types": {
-          "version": "15.6.2",
-          "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.2.tgz",
-          "integrity": "sha512-3pboPvLiWD7dkI3qf3KbUe6hKFKa52w+AE0VCqECtf+QHAKgOL37tTaNCnuX1nAAQ4ZhyP+kYVKf8rLmJ/feDQ==",
-          "requires": {
-            "loose-envify": "1.4.0",
-            "object-assign": "4.1.1"
-          }
-        }
       }
     },
     "read-pkg": {
@@ -4185,11 +4145,6 @@
       "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
       "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
       "dev": true
-    },
-    "tslib": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
-      "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ=="
     },
     "type-check": {
       "version": "0.3.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-admin-date-inputs",
-  "version": "1.1.0",
+  "version": "1.0.21",
   "description": "react-admin-date-inputs",
   "main": "lib/index.js",
   "author": "vascofg",
@@ -46,11 +46,10 @@
   "peerDependencies": {
     "react": "^16.3.0",
     "prop-types": "^15.6.0",
-    "react-admin": "^2.6.0"
+    "react-admin": "^2.1.0"
   },
   "dependencies": {
-    "@date-io/date-fns": "^1.0.1",
-    "date-fns": "2.0.0-alpha.25",
-    "material-ui-pickers": "^2.1.1"
+    "date-fns": "2.0.0-alpha.16",
+    "material-ui-pickers": "1.0.0-rc.17"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,12 +1,13 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { addField, FieldTitle } from 'ra-core';
-import { DatePicker, TimePicker, DateTimePicker, MuiPickersUtilsProvider } from 'material-ui-pickers';
-import DateFnsUtils from '@date-io/date-fns';
+import { DatePicker, TimePicker, DateTimePicker } from 'material-ui-pickers';
+import DateFnsUtils from 'material-ui-pickers/utils/date-fns-utils';
+import MuiPickersUtilsProvider from 'material-ui-pickers/utils/MuiPickersUtilsProvider';
 
 const makePicker = (PickerComponent) => {
   class _makePicker extends Component {
-    onChange = (date) => {
+    onChange(date) {
       this.props.input.onChange(date);
       this.props.input.onBlur();
     }
@@ -43,7 +44,7 @@ const makePicker = (PickerComponent) => {
               ref={(node) => { this.picker = node; }}
               className={className}
               value={input.value ? input.value : null}
-              onChange={this.onChange}
+              onChange={date => this.onChange(date)}
             />
           </MuiPickersUtilsProvider>
         </div>


### PR DESCRIPTION
Reverts vascofg/react-admin-date-inputs#17
I mistakenly merged this. react-admin still isn't on material-ui@3.2