### PR TITLE
migration to material-ui-pickers 2.x

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,7 +1,9 @@
 {
-    "extends": "airbnb",
-    "rules": {
-        "react/jsx-filename-extension": 0,
-        "react/forbid-prop-types": 0
-    }
+  "extends": "airbnb",
+  "rules": {
+    "react/jsx-filename-extension": 0,
+    "react/forbid-prop-types": 0
+  },
+  "env": { "es6": true },
+  "parser": "babel-eslint"
 }

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.js text eol=lf

--- a/lib/index.js
+++ b/lib/index.js
@@ -21,13 +21,9 @@ var _raCore = require('ra-core');
 
 var _materialUiPickers = require('material-ui-pickers');
 
-var _dateFnsUtils = require('material-ui-pickers/utils/date-fns-utils');
+var _dateFns = require('@date-io/date-fns');
 
-var _dateFnsUtils2 = _interopRequireDefault(_dateFnsUtils);
-
-var _MuiPickersUtilsProvider = require('material-ui-pickers/utils/MuiPickersUtilsProvider');
-
-var _MuiPickersUtilsProvider2 = _interopRequireDefault(_MuiPickersUtilsProvider);
+var _dateFns2 = _interopRequireDefault(_dateFns);
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
@@ -76,7 +72,7 @@ var makePicker = function makePicker(PickerComponent) {
           'div',
           { className: 'picker' },
           _react2.default.createElement(
-            _MuiPickersUtilsProvider2.default,
+            _materialUiPickers.MuiPickersUtilsProvider,
             providerOptions,
             _react2.default.createElement(PickerComponent, _extends({}, options, {
               label: _react2.default.createElement(_raCore.FieldTitle, {
@@ -93,9 +89,7 @@ var makePicker = function makePicker(PickerComponent) {
               },
               className: className,
               value: input.value ? input.value : null,
-              onChange: function onChange(date) {
-                return _this2.onChange(date);
-              }
+              onChange: this.onChange
             }))
           )
         );
@@ -132,7 +126,7 @@ var makePicker = function makePicker(PickerComponent) {
     labelTime: '',
     className: '',
     providerOptions: {
-      utils: _dateFnsUtils2.default,
+      utils: _dateFns2.default,
       locale: undefined
     }
   };

--- a/lib/index.js
+++ b/lib/index.js
@@ -38,18 +38,23 @@ var makePicker = function makePicker(PickerComponent) {
     _inherits(_makePicker, _Component);
 
     function _makePicker() {
+      var _ref;
+
+      var _temp, _this, _ret;
+
       _classCallCheck(this, _makePicker);
 
-      return _possibleConstructorReturn(this, (_makePicker.__proto__ || Object.getPrototypeOf(_makePicker)).apply(this, arguments));
+      for (var _len = arguments.length, args = Array(_len), _key = 0; _key < _len; _key++) {
+        args[_key] = arguments[_key];
+      }
+
+      return _ret = (_temp = (_this = _possibleConstructorReturn(this, (_ref = _makePicker.__proto__ || Object.getPrototypeOf(_makePicker)).call.apply(_ref, [this].concat(args))), _this), _this.onChange = function (date) {
+        _this.props.input.onChange(date);
+        _this.props.input.onBlur();
+      }, _temp), _possibleConstructorReturn(_this, _ret);
     }
 
     _createClass(_makePicker, [{
-      key: 'onChange',
-      value: function onChange(date) {
-        this.props.input.onChange(date);
-        this.props.input.onBlur();
-      }
-    }, {
       key: 'render',
       value: function render() {
         var _this2 = this;

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@babel/runtime": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.0.0.tgz",
-      "integrity": "sha512-7hGhzlcmg01CvH1EHdSPVXYX1aJ8KCEyz6I9xYIi/asDtzBPMyMhVibhM/K6g/5qnKBwjZtp10bNZIEFTRW1MA==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.2.0.tgz",
+      "integrity": "sha512-oouEibCbHMVdZSDlJBO6bZmID/zA/G/Qx3H1d3rSNPTD+L8UNKvCat7aKWSJ74zYbm5zWGh0GQN0hKj8zYFTCg==",
       "requires": {
         "regenerator-runtime": "0.12.1"
       },
@@ -20,16 +20,38 @@
       }
     },
     "@date-io/core": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/@date-io/core/-/core-0.0.2.tgz",
-      "integrity": "sha512-rkanRee2Agpw3tZLaCGJxkNRzi7FdyqueQDmEZAgZfIQaPo0MoOrO0gcTGwhTNREV8+OBKiZLpbaHK79dsU/Wg=="
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@date-io/core/-/core-1.0.1.tgz",
+      "integrity": "sha512-vUdpOjCyjjDXjooyy+1MGCbw2BI00M/avAk+S8hQVs8CrLW78w7HdPFfVVpywC5f1ygueGc6IkSBVj0yawYGEg=="
     },
     "@date-io/date-fns": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/@date-io/date-fns/-/date-fns-0.0.2.tgz",
-      "integrity": "sha512-MGcRweZCAQ3O2RNfwflH9zF2MgwNpYxRBpcVm4adhyZLKxG4xUQTJvQ/BtO93/MEbjcpGgNS0Yfej/96eTKFfQ==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@date-io/date-fns/-/date-fns-1.0.1.tgz",
+      "integrity": "sha512-egGn37+ReN1OhxfwiwngOiddalzauENg7Lf53EbcxlYYw8SRgxmvS5zxdG07AlDrPLCQg5tGqpqLyj3o3nsj0A==",
       "requires": {
-        "@date-io/core": "0.0.2"
+        "@date-io/core": "1.0.1"
+      }
+    },
+    "@types/prop-types": {
+      "version": "15.5.8",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.5.8.tgz",
+      "integrity": "sha512-3AQoUxQcQtLHsK25wtTWIoIpgYjH3vSDroZOUr7PpCHw/jLY1RB9z9E8dBT/OSmwStVgkRNvdh+ZHNiomRieaw=="
+    },
+    "@types/react": {
+      "version": "16.7.20",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.7.20.tgz",
+      "integrity": "sha512-Qd5RWkwl6SL7R2XzLk/cicjVQm1Mhc6HqXY5Ei4pWd1Vi8Fkbd5O0sA398x8fRSTPAuHdDYD9nrWmJMYTJI0vQ==",
+      "requires": {
+        "@types/prop-types": "15.5.8",
+        "csstype": "2.6.1"
+      }
+    },
+    "@types/react-text-mask": {
+      "version": "5.4.3",
+      "resolved": "https://registry.npmjs.org/@types/react-text-mask/-/react-text-mask-5.4.3.tgz",
+      "integrity": "sha512-+/uibOQ07X4om3+dPMpxUGdw76u4d4HQ9qCPs2syFtwmpTlnOyAJaIW89t+QX/DXI+Ar+SKch6A4stoLg5RdLw==",
+      "requires": {
+        "@types/react": "16.7.20"
       }
     },
     "acorn": {
@@ -1494,6 +1516,11 @@
         "which": "1.3.1"
       }
     },
+    "csstype": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.1.tgz",
+      "integrity": "sha512-wv7IRqCGsL7WGKB8gPvrl+++HlFM9kxAM6jL1EXNPNTshEJYilMkbfS2SnuHha77uosp/YVK0wAp2jmlBzn1tg=="
+    },
     "damerau-levenshtein": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.4.tgz",
@@ -1568,22 +1595,7 @@
       "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-3.4.0.tgz",
       "integrity": "sha512-LnuPJ+dwqKDIyotW1VzmOZ5TONUN7CwkCR5hrgawTUbkBGYdeoNLZo6nNfGkCrjtE1nXXaj7iMMpDa8/d9WoIA==",
       "requires": {
-        "@babel/runtime": "7.1.5"
-      },
-      "dependencies": {
-        "@babel/runtime": {
-          "version": "7.1.5",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.1.5.tgz",
-          "integrity": "sha512-xKnPpXG/pvK1B90JkwwxSGii90rQGKtzcMt2gI5G6+M0REXaq6rOHsGC2ay6/d0Uje7zzvSzjEzfR3ENhFlrfA==",
-          "requires": {
-            "regenerator-runtime": "0.12.1"
-          }
-        },
-        "regenerator-runtime": {
-          "version": "0.12.1",
-          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz",
-          "integrity": "sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg=="
-        }
+        "@babel/runtime": "7.2.0"
       }
     },
     "emoji-regex": {
@@ -3210,15 +3222,16 @@
       }
     },
     "material-ui-pickers": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/material-ui-pickers/-/material-ui-pickers-2.0.2.tgz",
-      "integrity": "sha512-c3reNpv4ytl1DdV2+zxRDKD3obL+TjrKlWtK4P4KxcbG/hja6zAO8wwwi578YjxvTDooX9Y1pzpvBwLCYu05zQ==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/material-ui-pickers/-/material-ui-pickers-2.1.1.tgz",
+      "integrity": "sha512-p4qxZv+kkhFAGdw172lFLmbA127kUS8XkqlTPWu2km7f+FRHzk1b4GwP63FEXB+dzhj+xa5VJ7WltaLxUMROTg==",
       "requires": {
+        "@types/react-text-mask": "5.4.3",
         "classnames": "2.2.6",
         "keycode": "2.2.0",
-        "react-event-listener": "0.6.4",
+        "react-event-listener": "0.6.5",
         "react-text-mask": "5.4.1",
-        "react-transition-group": "2.5.0",
+        "react-transition-group": "2.5.3",
         "tslib": "1.9.3"
       }
     },
@@ -3633,11 +3646,11 @@
       }
     },
     "react-event-listener": {
-      "version": "0.6.4",
-      "resolved": "https://registry.npmjs.org/react-event-listener/-/react-event-listener-0.6.4.tgz",
-      "integrity": "sha512-t7VSjIuUFmN+GeyKb+wm025YLeojVB85kJL6sSs0wEBJddfmKBEQz+CNBZ2zBLKVWkPy/fZXM6U5yvojjYBVYQ==",
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/react-event-listener/-/react-event-listener-0.6.5.tgz",
+      "integrity": "sha512-//lCxOM3DQ0+xmTa/u9mI9mm55zCPdIKp89d8MGjlNsOOnXQ5sFDD1eed+sMBzQXKiRBLBMtSg/2T9RJFtfovw==",
       "requires": {
-        "@babel/runtime": "7.0.0",
+        "@babel/runtime": "7.2.0",
         "prop-types": "15.6.1",
         "warning": "4.0.2"
       }
@@ -3656,9 +3669,9 @@
       }
     },
     "react-transition-group": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-2.5.0.tgz",
-      "integrity": "sha512-qYB3JBF+9Y4sE4/Mg/9O6WFpdoYjeeYqx0AFb64PTazVy8RPMiE3A47CG9QmM4WJ/mzDiZYslV+Uly6O1Erlgw==",
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-2.5.3.tgz",
+      "integrity": "sha512-2DGFck6h99kLNr8pOFk+z4Soq3iISydwOFeeEVPjTN6+Y01CmvbWmnN02VuTWyFdnRtIDPe+wy2q6Ui8snBPZg==",
       "requires": {
         "dom-helpers": "3.4.0",
         "loose-envify": "1.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,9 +1,37 @@
 {
   "name": "react-admin-date-inputs",
-  "version": "1.0.21",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@babel/runtime": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.0.0.tgz",
+      "integrity": "sha512-7hGhzlcmg01CvH1EHdSPVXYX1aJ8KCEyz6I9xYIi/asDtzBPMyMhVibhM/K6g/5qnKBwjZtp10bNZIEFTRW1MA==",
+      "requires": {
+        "regenerator-runtime": "0.12.1"
+      },
+      "dependencies": {
+        "regenerator-runtime": {
+          "version": "0.12.1",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz",
+          "integrity": "sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg=="
+        }
+      }
+    },
+    "@date-io/core": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/@date-io/core/-/core-0.0.2.tgz",
+      "integrity": "sha512-rkanRee2Agpw3tZLaCGJxkNRzi7FdyqueQDmEZAgZfIQaPo0MoOrO0gcTGwhTNREV8+OBKiZLpbaHK79dsU/Wg=="
+    },
+    "@date-io/date-fns": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/@date-io/date-fns/-/date-fns-0.0.2.tgz",
+      "integrity": "sha512-MGcRweZCAQ3O2RNfwflH9zF2MgwNpYxRBpcVm4adhyZLKxG4xUQTJvQ/BtO93/MEbjcpGgNS0Yfej/96eTKFfQ==",
+      "requires": {
+        "@date-io/core": "0.0.2"
+      }
+    },
     "acorn": {
       "version": "5.6.2",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.6.2.tgz",
@@ -1473,9 +1501,9 @@
       "dev": true
     },
     "date-fns": {
-      "version": "2.0.0-alpha.16",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.0.0-alpha.16.tgz",
-      "integrity": "sha1-0kmmybeZJSZS+54/JUYOr53oasc="
+      "version": "2.0.0-alpha.25",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.0.0-alpha.25.tgz",
+      "integrity": "sha512-iQzJkHF0L4wah9Ae9PkvwemwFz6qmRLuNZcghmvf2t+ptLs1qXzONLiGtjmPQzL6+JpC01JjlTopY2AEy4NFAg=="
     },
     "debug": {
       "version": "2.6.9",
@@ -1536,9 +1564,27 @@
       }
     },
     "dom-helpers": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-3.3.1.tgz",
-      "integrity": "sha512-2Sm+JaYn74OiTM2wHvxJOo3roiq/h25Yi69Fqk269cNUwIXsCvATB6CRSFC9Am/20G2b28hGv/+7NiWydIrPvg=="
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-3.4.0.tgz",
+      "integrity": "sha512-LnuPJ+dwqKDIyotW1VzmOZ5TONUN7CwkCR5hrgawTUbkBGYdeoNLZo6nNfGkCrjtE1nXXaj7iMMpDa8/d9WoIA==",
+      "requires": {
+        "@babel/runtime": "7.1.5"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.1.5",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.1.5.tgz",
+          "integrity": "sha512-xKnPpXG/pvK1B90JkwwxSGii90rQGKtzcMt2gI5G6+M0REXaq6rOHsGC2ay6/d0Uje7zzvSzjEzfR3ENhFlrfA==",
+          "requires": {
+            "regenerator-runtime": "0.12.1"
+          }
+        },
+        "regenerator-runtime": {
+          "version": "0.12.1",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz",
+          "integrity": "sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg=="
+        }
+      }
     },
     "emoji-regex": {
       "version": "6.5.1",
@@ -3073,6 +3119,11 @@
         "array-includes": "3.0.3"
       }
     },
+    "keycode": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/keycode/-/keycode-2.2.0.tgz",
+      "integrity": "sha1-PQr1bce4uOXLqNCpfxByBO7CKwQ="
+    },
     "kind-of": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
@@ -3159,80 +3210,16 @@
       }
     },
     "material-ui-pickers": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/material-ui-pickers/-/material-ui-pickers-1.0.0-rc.17.tgz",
-      "integrity": "sha512-mzNbMmqTkPhZqfb2nVQ1jBIOb0QUDTMVs6RnqTccCnqPJ8iea5d+P9KTnjyObkeE+Kt0+Fn7OX1+v/w3h0tbHg==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/material-ui-pickers/-/material-ui-pickers-2.0.2.tgz",
+      "integrity": "sha512-c3reNpv4ytl1DdV2+zxRDKD3obL+TjrKlWtK4P4KxcbG/hja6zAO8wwwi578YjxvTDooX9Y1pzpvBwLCYu05zQ==",
       "requires": {
-        "@babel/runtime": "7.1.5",
         "classnames": "2.2.6",
+        "keycode": "2.2.0",
         "react-event-listener": "0.6.4",
         "react-text-mask": "5.4.1",
-        "react-transition-group": "2.5.0"
-      },
-      "dependencies": {
-        "@babel/runtime": {
-          "version": "7.1.5",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.1.5.tgz",
-          "integrity": "sha512-xKnPpXG/pvK1B90JkwwxSGii90rQGKtzcMt2gI5G6+M0REXaq6rOHsGC2ay6/d0Uje7zzvSzjEzfR3ENhFlrfA==",
-          "requires": {
-            "regenerator-runtime": "0.12.1"
-          }
-        },
-        "loose-envify": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
-          "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-          "requires": {
-            "js-tokens": "3.0.2"
-          }
-        },
-        "react-event-listener": {
-          "version": "0.6.4",
-          "resolved": "https://registry.npmjs.org/react-event-listener/-/react-event-listener-0.6.4.tgz",
-          "integrity": "sha512-t7VSjIuUFmN+GeyKb+wm025YLeojVB85kJL6sSs0wEBJddfmKBEQz+CNBZ2zBLKVWkPy/fZXM6U5yvojjYBVYQ==",
-          "requires": {
-            "@babel/runtime": "7.0.0",
-            "prop-types": "15.6.1",
-            "warning": "4.0.2"
-          },
-          "dependencies": {
-            "@babel/runtime": {
-              "version": "7.0.0",
-              "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.0.0.tgz",
-              "integrity": "sha512-7hGhzlcmg01CvH1EHdSPVXYX1aJ8KCEyz6I9xYIi/asDtzBPMyMhVibhM/K6g/5qnKBwjZtp10bNZIEFTRW1MA==",
-              "requires": {
-                "regenerator-runtime": "0.12.1"
-              }
-            }
-          }
-        },
-        "react-transition-group": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-2.5.0.tgz",
-          "integrity": "sha512-qYB3JBF+9Y4sE4/Mg/9O6WFpdoYjeeYqx0AFb64PTazVy8RPMiE3A47CG9QmM4WJ/mzDiZYslV+Uly6O1Erlgw==",
-          "requires": {
-            "dom-helpers": "3.3.1",
-            "loose-envify": "1.4.0",
-            "prop-types": "15.6.2",
-            "react-lifecycles-compat": "3.0.4"
-          },
-          "dependencies": {
-            "prop-types": {
-              "version": "15.6.2",
-              "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.2.tgz",
-              "integrity": "sha512-3pboPvLiWD7dkI3qf3KbUe6hKFKa52w+AE0VCqECtf+QHAKgOL37tTaNCnuX1nAAQ4ZhyP+kYVKf8rLmJ/feDQ==",
-              "requires": {
-                "loose-envify": "1.4.0",
-                "object-assign": "4.1.1"
-              }
-            }
-          }
-        },
-        "regenerator-runtime": {
-          "version": "0.12.1",
-          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz",
-          "integrity": "sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg=="
-        }
+        "react-transition-group": "2.5.0",
+        "tslib": "1.9.3"
       }
     },
     "math-random": {
@@ -3645,6 +3632,16 @@
         }
       }
     },
+    "react-event-listener": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/react-event-listener/-/react-event-listener-0.6.4.tgz",
+      "integrity": "sha512-t7VSjIuUFmN+GeyKb+wm025YLeojVB85kJL6sSs0wEBJddfmKBEQz+CNBZ2zBLKVWkPy/fZXM6U5yvojjYBVYQ==",
+      "requires": {
+        "@babel/runtime": "7.0.0",
+        "prop-types": "15.6.1",
+        "warning": "4.0.2"
+      }
+    },
     "react-lifecycles-compat": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
@@ -3656,6 +3653,36 @@
       "integrity": "sha512-mGx1n0x0skktwsKcpgAGnrgExFlXDflbWEHh8PC1UaQP8+EdHkW7JYczTghsBo2rnVwU9/4A9x/2bVt3HY46/w==",
       "requires": {
         "prop-types": "15.6.1"
+      }
+    },
+    "react-transition-group": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-2.5.0.tgz",
+      "integrity": "sha512-qYB3JBF+9Y4sE4/Mg/9O6WFpdoYjeeYqx0AFb64PTazVy8RPMiE3A47CG9QmM4WJ/mzDiZYslV+Uly6O1Erlgw==",
+      "requires": {
+        "dom-helpers": "3.4.0",
+        "loose-envify": "1.4.0",
+        "prop-types": "15.6.2",
+        "react-lifecycles-compat": "3.0.4"
+      },
+      "dependencies": {
+        "loose-envify": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+          "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+          "requires": {
+            "js-tokens": "3.0.2"
+          }
+        },
+        "prop-types": {
+          "version": "15.6.2",
+          "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.2.tgz",
+          "integrity": "sha512-3pboPvLiWD7dkI3qf3KbUe6hKFKa52w+AE0VCqECtf+QHAKgOL37tTaNCnuX1nAAQ4ZhyP+kYVKf8rLmJ/feDQ==",
+          "requires": {
+            "loose-envify": "1.4.0",
+            "object-assign": "4.1.1"
+          }
+        }
       }
     },
     "read-pkg": {
@@ -4145,6 +4172,11 @@
       "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
       "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
       "dev": true
+    },
+    "tslib": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
+      "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ=="
     },
     "type-check": {
       "version": "0.3.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-admin-date-inputs",
-  "version": "1.0.21",
+  "version": "1.1.0",
   "description": "react-admin-date-inputs",
   "main": "lib/index.js",
   "author": "vascofg",
@@ -49,7 +49,8 @@
     "react-admin": "^2.1.0"
   },
   "dependencies": {
-    "date-fns": "2.0.0-alpha.16",
-    "material-ui-pickers": "1.0.0-rc.17"
+    "@date-io/date-fns": "0.0.2",
+    "date-fns": "2.0.0-alpha.25",
+    "material-ui-pickers": "^2.0.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -46,11 +46,11 @@
   "peerDependencies": {
     "react": "^16.3.0",
     "prop-types": "^15.6.0",
-    "react-admin": "^2.1.0"
+    "react-admin": "^2.6.0"
   },
   "dependencies": {
-    "@date-io/date-fns": "0.0.2",
+    "@date-io/date-fns": "^1.0.1",
     "date-fns": "2.0.0-alpha.25",
-    "material-ui-pickers": "^2.0.2"
+    "material-ui-pickers": "^2.1.1"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,9 +1,8 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { addField, FieldTitle } from 'ra-core';
-import { DatePicker, TimePicker, DateTimePicker } from 'material-ui-pickers';
-import DateFnsUtils from 'material-ui-pickers/utils/date-fns-utils';
-import MuiPickersUtilsProvider from 'material-ui-pickers/utils/MuiPickersUtilsProvider';
+import { DatePicker, TimePicker, DateTimePicker, MuiPickersUtilsProvider } from 'material-ui-pickers';
+import DateFnsUtils from '@date-io/date-fns';
 
 const makePicker = (PickerComponent) => {
   class _makePicker extends Component {
@@ -44,7 +43,7 @@ const makePicker = (PickerComponent) => {
               ref={(node) => { this.picker = node; }}
               className={className}
               value={input.value ? input.value : null}
-              onChange={date => this.onChange(date)}
+              onChange={this.onChange}
             />
           </MuiPickersUtilsProvider>
         </div>

--- a/src/index.js
+++ b/src/index.js
@@ -6,7 +6,7 @@ import DateFnsUtils from '@date-io/date-fns';
 
 const makePicker = (PickerComponent) => {
   class _makePicker extends Component {
-    onChange(date) {
+    onChange = (date) => {
       this.props.input.onChange(date);
       this.props.input.onBlur();
     }


### PR DESCRIPTION
Won't be able to merge this until react-admin updates to @material-ui/core 3.2.0 or above, because of this:
https://github.com/dmtrKovalenko/material-ui-pickers/commit/8b35d655fdde44d34be17a0afb8176bd6a870122

This is the module that must be updated: https://github.com/marmelab/react-admin/blob/master/packages/ra-ui-materialui/package.json