### PR TITLE
Do not set default label value

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -70,7 +70,6 @@ const makePicker = (PickerComponent) => {
   _makePicker.defaultProps = {
     input: {},
     isRequired: 'false',
-    label: '',
     meta: { touched: false, error: false },
     options: {},
     resource: '',


### PR DESCRIPTION
This makes label work out of the box.

See:
https://github.com/marmelab/react-admin/blob/master/packages/ra-core/src/util/getFieldLabelTranslationArgs.ts#L28

`label` should be `undefined` in order to get translation from i18n provider